### PR TITLE
feature: Use the same cdk version as your deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start:frontend": "cd frontend && npm run dev",
     "install:all": "cd backend && npm i && cd ../ && cd frontend && npm i",
-    "deploy": "cd backend && cdk deploy --all",
+    "deploy": "cd backend && ./node_modules/.bin/cdk deploy --all",
     "populate-db": "node backend/scripts/insert-data-into-ddb.js"
   },
   "keywords": [],


### PR DESCRIPTION
That way it doesn't require you to install CDK globally and always have the correct bin version. Best practice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
